### PR TITLE
```text

### DIFF
--- a/src/prisma/migrations/20240715075439_contract_created_at_not_null/migration.sql
+++ b/src/prisma/migrations/20240715075439_contract_created_at_not_null/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `contract_created_at` on table `contracts` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "contracts" ALTER COLUMN "contract_created_at" SET NOT NULL;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -65,7 +65,7 @@ model contracts {
   terminal_id               String?        @db.Uuid
   account_id                String         @db.Uuid
   creator_id                String         @db.VarChar(255)
-  contract_created_at       DateTime?      @default(now()) @db.Timestamptz(6)
+  contract_created_at       DateTime       @default(now()) @db.Timestamptz(6)
   accounts                  accounts       @relation(fields: [account_id], references: [account_id], onDelete: NoAction, onUpdate: NoAction)
   terminals                 terminals?     @relation(fields: [terminal_id], references: [terminal_id], onDelete: NoAction, onUpdate: NoAction)
   transactions              transactions[]

--- a/src/src/app.controller.ts
+++ b/src/src/app.controller.ts
@@ -8,6 +8,6 @@ export class AppController {
 
   @Get('/')
   getRoot(): string {
-    return 'maj bdd';
+    return 'test ';
   }
 }


### PR DESCRIPTION
chore: Update contracts table to make contract_created_at column not null

This commit updates the contracts table in the database to make the contract_created_at column not null. Previously, it was nullable, but now it is required. This change ensures that all contracts have a valid creation date and prevents any existing null values from causing issues.